### PR TITLE
Fix slot selection reset when changing venue type

### DIFF
--- a/src/public/js/faculty-allocation.js
+++ b/src/public/js/faculty-allocation.js
@@ -779,6 +779,9 @@ function updateAvailableSlots(course) {
 
   if (!year || !semesterType) return;
 
+  // Save current selection before clearing dropdown
+  const previouslySelectedSlot = allocationSlotNameInput.value;
+
   // Include the component type in the API call
   fetch(
     `${window.API_URL}/faculty-allocations/available-slots?` +
@@ -816,6 +819,18 @@ function updateAvailableSlots(course) {
 
           allocationSlotNameInput.appendChild(option);
         });
+
+        // Restore previous selection if it exists in the new options
+        if (
+          previouslySelectedSlot &&
+          data.availableSlots.includes(previouslySelectedSlot)
+        ) {
+          allocationSlotNameInput.value = previouslySelectedSlot;
+
+          // Trigger the change event to update slot day display
+          const changeEvent = new Event("change");
+          allocationSlotNameInput.dispatchEvent(changeEvent);
+        }
       } else {
         console.warn("No available slots returned from API");
         // Add a message to the dropdown


### PR DESCRIPTION
## Issue
When creating a faculty allocation, selecting a slot name and then changing the venue type would reset the slot selection to "Select Slot", requiring users to reselect the same slot again.

## Solution
- Modified the `updateAvailableSlots()` function to preserve the user's slot selection when changing venue type
- Added logic to restore the previous selection after repopulating the dropdown
- Ensured slot day display is updated properly by triggering a change event

## Testing
- Tested locally by creating faculty allocations and verifying that slot selection is preserved when changing venue type