### PR TITLE
Enhance timetable borders and legends

### DIFF
--- a/src/public/css/style.css
+++ b/src/public/css/style.css
@@ -123,3 +123,45 @@ main {
     height: auto;
   }
 }
+
+/* Timetable border styling - Enhanced borders for all timetable cells */
+.timetable-container {
+  border: 2px solid black !important; /* Thick outer border */
+}
+
+.timetable-container th,
+.timetable-container td {
+  border: 1px solid black !important; /* All cells have black borders */
+}
+
+/* Summary table styling - For class timetable legend table */
+.summary-table,
+.summary-table th,
+.summary-table td {
+  border: 1px solid black !important;
+  border-collapse: collapse;
+}
+
+.summary-table th {
+  background-color: #f8f9fa;
+  font-weight: bold;
+  text-align: center;
+  padding: 8px;
+}
+
+.summary-table td {
+  padding: 8px;
+  text-align: center;
+}
+
+.summary-table td:first-child {
+  text-align: center; /* Serial number column */
+}
+
+.summary-table td:nth-child(4) {
+  text-align: left; /* Course title column */
+}
+
+.summary-table td:last-child {
+  text-align: left; /* Faculty name column */
+}

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -849,7 +849,7 @@
 
                     <div class="table-responsive">
                       <table
-                        class="table table-bordered"
+                        class="table table-bordered timetable-container"
                         id="master-slot-table"
                       >
                         <thead>

--- a/src/public/js/faculty-allocation.js
+++ b/src/public/js/faculty-allocation.js
@@ -1779,7 +1779,7 @@ function generateFacultyTimetable(faculty, allocations, year, semester) {
 
   // Generate HTML table
   let tableHtml = `
-      <table class="table table-bordered">
+    <table class="table table-bordered timetable-container">
         <thead>
           <tr class="table-primary">
             <th></th>
@@ -1870,16 +1870,15 @@ function generateFacultyTimetable(faculty, allocations, year, semester) {
   tableHtml += "</tbody></table>";
 
   // Add abbreviations note
-  let abbreviationsNote = "<p><strong>Course Abbreviations:</strong><br>";
+  let courseInfo = "";
   Object.entries(courseAbbreviations).forEach(([code, data]) => {
-    abbreviationsNote += `${data.abbr} - ${data.full}<br>`;
+    courseInfo += `<p><strong>${code}: ${data.full}</strong></p>`;
   });
-  abbreviationsNote += "</p>";
 
   // Update the container
   const facultyTimetableDiv = document.getElementById("faculty-timetable-div");
   if (facultyTimetableDiv) {
-    facultyTimetableDiv.innerHTML = tableHtml + abbreviationsNote;
+    facultyTimetableDiv.innerHTML = tableHtml + courseInfo;
   }
 }
 // Generate class timetable
@@ -2037,7 +2036,7 @@ function generateClassTimetable(venue, allocations, year, semester) {
 
   // Generate HTML table
   let tableHtml = `
-      <table class="table table-bordered">
+      <table class="table table-bordered timetable-container">
         <thead>
           <tr class="table-primary">
             <th></th>
@@ -2117,22 +2116,75 @@ function generateClassTimetable(venue, allocations, year, semester) {
 
   tableHtml += "</tbody></table>";
 
-  // Add abbreviations note
-  let abbreviationsNote = "<p><strong>Abbreviations:</strong><br>";
-  abbreviationsNote += "<strong>Courses:</strong><br>";
-  Object.entries(courseAbbreviations).forEach(([code, data]) => {
-    abbreviationsNote += `${data.abbr} - ${data.full}<br>`;
+  // Create summary table with unique courses only
+  const uniqueCourses = {};
+  allocations.forEach((allocation) => {
+    if (!uniqueCourses[allocation.course_code]) {
+      uniqueCourses[allocation.course_code] = {
+        slot_names: [allocation.slot_name],
+        course_code: allocation.course_code,
+        course_name: allocation.course_name,
+        theory: allocation.theory,
+        practical: allocation.practical,
+        credits: allocation.credits,
+        faculty_name: allocation.faculty_name,
+      };
+    } else {
+      // Add slot name if not already present
+      if (
+        !uniqueCourses[allocation.course_code].slot_names.includes(
+          allocation.slot_name
+        )
+      ) {
+        uniqueCourses[allocation.course_code].slot_names.push(
+          allocation.slot_name
+        );
+      }
+    }
   });
-  abbreviationsNote += "<br><strong>Faculty:</strong><br>";
-  Object.entries(facultyAbbreviations).forEach(([id, data]) => {
-    abbreviationsNote += `${data.abbr} - ${data.full}<br>`;
+
+  let summaryTable = `
+    <div class="mt-4">
+      <table class="table summary-table">
+        <thead>
+          <tr>
+            <th>Sl. No.</th>
+            <th>Slot</th>
+            <th>Course Code</th>
+            <th>Course Title</th>
+            <th>T-P-C</th>
+            <th>Faculty</th>
+          </tr>
+        </thead>
+        <tbody>
+`;
+
+  // Add rows for each unique course
+  let serialNumber = 1;
+  Object.values(uniqueCourses).forEach((course) => {
+    summaryTable += `
+          <tr>
+            <td>${serialNumber}.</td>
+            <td>${course.slot_names.join(", ")}</td>
+            <td>${course.course_code}</td>
+            <td>${course.course_name}</td>
+            <td>${course.theory}-${course.practical}-${course.credits}</td>
+            <td>${course.faculty_name}</td>
+          </tr>
+  `;
+    serialNumber++;
   });
-  abbreviationsNote += "</p>";
+
+  summaryTable += `
+        </tbody>
+      </table>
+    </div>
+`;
 
   // Update the container
   const classTimetableDiv = document.getElementById("class-timetable-div");
   if (classTimetableDiv) {
-    classTimetableDiv.innerHTML = tableHtml + abbreviationsNote;
+    classTimetableDiv.innerHTML = tableHtml + summaryTable;
   }
 }
 


### PR DESCRIPTION
## Changes Made
- Added black borders to all timetable cells (thick outer borders, thin inner borders)
- Updated faculty timetable legend from abbreviations to 'CourseCode: CourseName' format  
- Replaced class timetable abbreviations with structured summary table
- Fixed duplicate course entries in class timetable summary
- Applied consistent styling across all three timetable views

## Testing
- ✅ All timetable views tested locally and working correctly
- ✅ Border styling applied consistently
- ✅ Legend formats updated as specified