### PR TITLE
Fix timetable coordinator permissions and UI issues

### DIFF
--- a/src/public/js/faculty-allocation.js
+++ b/src/public/js/faculty-allocation.js
@@ -469,32 +469,42 @@ function renderFacultyAllocations(allocations) {
     }</td>
         <td>${allocation.venue}</td>
         <td>
-          <button class="btn btn-sm btn-primary edit-allocation-btn" 
-            data-allocation='${JSON.stringify(allocation)}'>
-            <i class="fas fa-edit"></i>
-          </button>
-          <button class="btn btn-sm btn-danger delete-allocation-btn" 
-            data-allocation='${JSON.stringify(allocation)}'>
-            <i class="fas fa-trash"></i>
-          </button>
-        </td>
+  ${
+    currentUser && currentUser.role === "admin"
+      ? `
+    <button class="btn btn-sm btn-primary edit-allocation-btn" 
+      data-allocation='${JSON.stringify(allocation)}'>
+      <i class="fas fa-edit"></i>
+    </button>
+  `
+      : ""
+  }
+  <button class="btn btn-sm btn-danger delete-allocation-btn" 
+    data-allocation='${JSON.stringify(allocation)}'>
+    <i class="fas fa-trash"></i>
+  </button>
+</td>
       `;
     facultyAllocationTableBody.appendChild(row);
   });
 
   console.log("Finished rendering allocations");
 
-  // Add event listeners
+  // Remove any existing event listeners by cloning and replacing elements
   document.querySelectorAll(".edit-allocation-btn").forEach((btn) => {
-    btn.addEventListener("click", () => {
-      const allocation = JSON.parse(btn.getAttribute("data-allocation"));
+    const newBtn = btn.cloneNode(true);
+    btn.parentNode.replaceChild(newBtn, btn);
+    newBtn.addEventListener("click", () => {
+      const allocation = JSON.parse(newBtn.getAttribute("data-allocation"));
       openEditAllocationModal(allocation);
     });
   });
 
   document.querySelectorAll(".delete-allocation-btn").forEach((btn) => {
-    btn.addEventListener("click", () => {
-      const allocation = JSON.parse(btn.getAttribute("data-allocation"));
+    const newBtn = btn.cloneNode(true);
+    btn.parentNode.replaceChild(newBtn, btn);
+    newBtn.addEventListener("click", () => {
+      const allocation = JSON.parse(newBtn.getAttribute("data-allocation"));
       openDeleteAllocationModal(allocation);
     });
   });

--- a/src/public/js/main.js
+++ b/src/public/js/main.js
@@ -125,17 +125,20 @@ function updateNavigationByRole(userRole) {
       break;
 
     case "timetable_coordinator":
-      // Coordinator sees: Dashboard, TimeTable (all), Timetable Coordinator, Logout
-      [
-        navItems.dashboard,
-        navItems.timetable,
-        navItems.timetableCoordinator,
-        navItems.logout,
-      ].forEach((item) => {
-        if (item && item.parentElement) {
-          item.parentElement.style.display = "block";
+      // Coordinator sees: Dashboard, TimeTable (view only), Logout
+      [navItems.dashboard, navItems.timetable, navItems.logout].forEach(
+        (item) => {
+          if (item && item.parentElement) {
+            item.parentElement.style.display = "block";
+          }
         }
-      });
+      );
+
+      // Show timetable but customize submenu for coordinators (view only)
+      if (navItems.timetable && navItems.timetable.parentElement) {
+        navItems.timetable.parentElement.style.display = "block";
+        customizeTimetableMenuForCoordinator();
+      }
       break;
 
     case "faculty":
@@ -191,6 +194,33 @@ function customizeTimetableMenuForFaculty() {
   }
   if (viewFacultySlotLink && viewFacultySlotLink.parentElement) {
     viewFacultySlotLink.parentElement.style.display = "block";
+  }
+  if (viewClassSlotLink && viewClassSlotLink.parentElement) {
+    viewClassSlotLink.parentElement.style.display = "block";
+  }
+}
+
+// Customize timetable menu for coordinators (view only for master slots, full access for faculty allocations)
+function customizeTimetableMenuForCoordinator() {
+  const timetableSubmenu = document.getElementById("timetable-submenu");
+  if (!timetableSubmenu) return;
+
+  // Hide master slot creation options for coordinators
+  const createSlotLink = document.getElementById("create-slot-link");
+  if (createSlotLink && createSlotLink.parentElement) {
+    createSlotLink.parentElement.style.display = "none";
+  }
+
+  // Show all other timetable options (view master slots, faculty allocations, class slots)
+  const viewSlotLink = document.getElementById("view-slot-link");
+  const facultySlotSection = document.getElementById("faculty-slot-link");
+  const viewClassSlotLink = document.getElementById("view-class-slot-link");
+
+  if (viewSlotLink && viewSlotLink.parentElement) {
+    viewSlotLink.parentElement.style.display = "block";
+  }
+  if (facultySlotSection && facultySlotSection.parentElement) {
+    facultySlotSection.parentElement.style.display = "block";
   }
   if (viewClassSlotLink && viewClassSlotLink.parentElement) {
     viewClassSlotLink.parentElement.style.display = "block";

--- a/src/public/js/slots.js
+++ b/src/public/js/slots.js
@@ -191,6 +191,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Load academic years for filter
       populateAcademicYears();
+
+      // Hide "Add New Slot" button for coordinators
+      const addSlotBtn = document.getElementById("add-slot-btn");
+      if (addSlotBtn && currentUser && currentUser.role !== "admin") {
+        addSlotBtn.style.display = "none";
+      }
     });
   }
 
@@ -549,29 +555,36 @@ function renderSlots(slots) {
         </span>
       </td>
       <td>
-        <button class="btn btn-sm btn-primary action-btn edit-slot-btn" data-id="${
-          slot.slot_id
-        }">
-          <i class="fas fa-edit"></i>
-        </button>
-        <button class="btn btn-sm btn-${
-          slot.is_active ? "warning" : "success"
-        } action-btn toggle-status-btn" data-id="${
+  ${
+    currentUser && currentUser.role === "admin"
+      ? `
+    <button class="btn btn-sm btn-primary action-btn edit-slot-btn" data-id="${
       slot.slot_id
-    }" data-active="${slot.is_active}">
-          <i class="fas fa-${slot.is_active ? "pause" : "play"}"></i>
-        </button>
-        <button class="btn btn-sm btn-danger action-btn delete-slot-btn" 
-          data-id="${slot.slot_id}" 
-          data-year="${slot.slot_year}" 
-          data-semester="${slot.semester_type}" 
-          data-day="${slot.slot_day}" 
-          data-name="${slot.slot_name}" 
-          data-time="${slot.slot_time}">
-          <i class="fas fa-trash"></i>
-        </button>
-      </td>
-    `;
+    }">
+      <i class="fas fa-edit"></i>
+    </button>
+    <button class="btn btn-sm btn-${
+      slot.is_active ? "warning" : "success"
+    } action-btn toggle-status-btn" data-id="${slot.slot_id}" data-active="${
+          slot.is_active
+        }">
+      <i class="fas fa-${slot.is_active ? "pause" : "play"}"></i>
+    </button>
+    <button class="btn btn-sm btn-danger action-btn delete-slot-btn" 
+      data-id="${slot.slot_id}" 
+      data-year="${slot.slot_year}" 
+      data-semester="${slot.semester_type}" 
+      data-day="${slot.slot_day}" 
+      data-name="${slot.slot_name}" 
+      data-time="${slot.slot_time}">
+      <i class="fas fa-trash"></i>
+    </button>
+  `
+      : `
+    <span class="text-muted">View Only</span>
+  `
+  }
+</td>    `;
 
     slotsTableBody.appendChild(row);
   });


### PR DESCRIPTION
- Remove Timetable Coordinator menu section for coordinators
- Hide master slot create/edit/delete buttons for coordinators
- Add view-only access to master slot timetable for coordinators
- Remove edit access for faculty allocations (coordinators can only delete)
- Fix multiple event listener issue causing multiple clicks
- Maintain full faculty allocation access for coordinators