### PR TITLE
Fix: Hide System Configuration from non-admin users

### DIFF
--- a/src/public/js/main.js
+++ b/src/public/js/main.js
@@ -103,6 +103,7 @@ function updateNavigationByRole(userRole) {
     students: document.getElementById("students-link"),
     timetable: document.getElementById("timetable-link"),
     timetableCoordinator: document.getElementById("timetable-coordinator-link"),
+    systemConfig: document.getElementById("system-config-link"),
     logout: document.getElementById("logout-link"),
   };
 


### PR DESCRIPTION
- Add system-config-link to navItems object in main.js
- System Configuration now only visible to admin users
- Hidden from timetable_coordinator and faculty users
- Resolves navigation permission issue