### PR TITLE
Fix: Add student_registrations table to sync script

### DIFF
--- a/src/db/sync-production-data.js
+++ b/src/db/sync-production-data.js
@@ -114,6 +114,18 @@ const SYNC_TABLES = [
       "allowed_slot_times",
     ],
   },
+  {
+    name: "student_registrations",
+    primaryKey: "id",
+    dependencies: [
+      "student",
+      "course",
+      "venue",
+      "program",
+      "slot",
+      "semester_slot_config",
+    ],
+  },
 ];
 
 async function testConnections() {


### PR DESCRIPTION
- Added student_registrations to SYNC_TABLES array
- Positioned after dependencies (student, course, venue, program, slot)
- Now syncs 16 tables instead of 15
- Fixes missing student registration data in local environment