### PR TITLE
feat: increase venue field length from 10 to 50 characters

### DIFF
--- a/src/db/migrations/increase_venue_field_length.sql
+++ b/src/db/migrations/increase_venue_field_length.sql
@@ -1,0 +1,18 @@
+-- Migration: Increase venue field length from VARCHAR(10) to VARCHAR(50)
+-- Date: 2025-08-25
+-- Description: Increases the venue field length to accommodate longer venue names
+
+BEGIN;
+
+-- Increase venue field length
+ALTER TABLE venue ALTER COLUMN venue TYPE VARCHAR(50);
+
+-- Add migration log entry
+INSERT INTO migration_log (migration_name, applied_at, description) 
+VALUES (
+    'increase_venue_field_length', 
+    CURRENT_TIMESTAMP, 
+    'Increased venue field length from VARCHAR(10) to VARCHAR(50)'
+) ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/src/db/schema/venue.sql
+++ b/src/db/schema/venue.sql
@@ -5,7 +5,7 @@ DROP TABLE IF EXISTS venue CASCADE;
 CREATE TABLE venue (
     venue_id SERIAL PRIMARY KEY,
     assigned_to_school VARCHAR(10),
-    venue VARCHAR(10) NOT NULL UNIQUE,
+    venue VARCHAR(50) NOT NULL UNIQUE,
     capacity INTEGER NOT NULL,
     infra_type VARCHAR(20) NOT NULL,
     seats INTEGER,

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -2817,11 +2817,11 @@
                   type="text"
                   class="form-control"
                   id="venue-name-field"
-                  maxlength="10"
+                  maxlength="50"
                   required
                 />
                 <div class="form-text">
-                  Enter venue name or code (max 10 characters).
+                  Enter venue name or code (max 50 characters).
                 </div>
               </div>
               <div class="mb-3">

--- a/src/public/js/venues.js
+++ b/src/public/js/venues.js
@@ -578,8 +578,8 @@ function handleSaveVenue() {
   }
 
   // Validate field lengths
-  if (venueName.length > 10) {
-    showAlert("Venue name must not exceed 10 characters.", "danger");
+  if (venueName.length > 50) {
+    showAlert("Venue name must not exceed 50 characters.", "danger");
     return;
   }
 


### PR DESCRIPTION
- Updated database schema to allow VARCHAR(50) for venue names
- Added migration script for database column alteration
- Updated frontend HTML input maxlength from 10 to 50
- Updated JavaScript validation to allow up to 50 characters
- Updated user help text to reflect new 50 character limit

