### PR TITLE
fix: update venue field length in faculty_allocation and attendance t…

### DIFF
--- a/src/db/migrations/fix_venue_field_length_references.sql
+++ b/src/db/migrations/fix_venue_field_length_references.sql
@@ -1,0 +1,21 @@
+-- Migration: Fix venue field length in referencing tables
+-- Date: 2025-08-26
+-- Description: Updates venue field length in faculty_allocation and attendance tables to match venue table (VARCHAR(50))
+
+BEGIN;
+
+-- Update faculty_allocation table venue field length
+ALTER TABLE faculty_allocation ALTER COLUMN venue TYPE VARCHAR(50);
+
+-- Update attendance table venue field length  
+ALTER TABLE attendance ALTER COLUMN venue TYPE VARCHAR(50);
+
+-- Add migration log entry
+INSERT INTO migration_log (migration_name, applied_at, description) 
+VALUES (
+    'fix_venue_field_length_references', 
+    CURRENT_TIMESTAMP, 
+    'Updated venue field length in faculty_allocation and attendance tables to VARCHAR(50)'
+) ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/src/db/schema/attendance.sql
+++ b/src/db/schema/attendance.sql
@@ -9,7 +9,7 @@ CREATE TABLE attendance (
     semester_type VARCHAR(10) NOT NULL,
     course_code VARCHAR(10) NOT NULL,
     employee_id INTEGER NOT NULL,
-    venue VARCHAR(10) NOT NULL,
+    venue VARCHAR(50) NOT NULL,
     slot_day VARCHAR(10) NOT NULL,
     slot_name VARCHAR(15) NOT NULL,
     slot_time VARCHAR(75) NOT NULL,

--- a/src/db/schema/faculty-allocation.sql
+++ b/src/db/schema/faculty-allocation.sql
@@ -7,7 +7,7 @@ CREATE TABLE faculty_allocation (
     semester_type VARCHAR(10) NOT NULL,
     course_code VARCHAR(10) NOT NULL,
     employee_id INTEGER NOT NULL,
-    venue VARCHAR(10) NOT NULL,
+    venue VARCHAR(50) NOT NULL,
     slot_day VARCHAR(10) NOT NULL,
     slot_name VARCHAR(15) NOT NULL,
     slot_time VARCHAR(75) NOT NULL,


### PR DESCRIPTION
…ables

- Updated faculty_allocation table venue field from VARCHAR(10) to VARCHAR(50)
- Updated attendance table venue field from VARCHAR(10) to VARCHAR(50)
- Added migration script for database column alterations
- Fixes 'value too long' error when allocating venues with names > 10 characters
