### PR TITLE
fix: remove user_id from student creation to prevent session mixing

### DIFF
--- a/src/controllers/student.controller.js
+++ b/src/controllers/student.controller.js
@@ -56,7 +56,6 @@ exports.createStudent = async (req, res) => {
   try {
     const {
       enrollment_no,
-      user_id,
       student_name,
       program_name,
       school_name,
@@ -67,7 +66,6 @@ exports.createStudent = async (req, res) => {
     // Validate required fields
     if (
       !enrollment_no ||
-      !user_id ||
       !student_name ||
       !program_name ||
       !school_name ||
@@ -116,27 +114,15 @@ exports.createStudent = async (req, res) => {
       });
     }
 
-    // Check if user_id already exists
-    const userIdCheck = await db.query(
-      "SELECT COUNT(*) FROM student WHERE user_id = $1",
-      [user_id]
-    );
+    // Skip user_id validation - will be set when user account is created
 
-    if (parseInt(userIdCheck.rows[0].count) > 0) {
-      return res.status(409).json({
-        message: "A student with this user ID already exists",
-      });
-    }
-
-    // Insert new student
-    const result = await db.query(
+    // Insert new student without user_id (will be set when user account is created)
+    await db.query(
       `INSERT INTO student 
-       (enrollment_no, user_id, student_name, program_id, school_id, program_name, school_name, year_admitted, email_id) 
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) 
-       RETURNING *`,
+       (enrollment_no, student_name, program_id, school_id, program_name, school_name, year_admitted, email_id) 
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
       [
         enrollment_no,
-        user_id,
         student_name,
         program_id,
         school_id,
@@ -172,7 +158,6 @@ exports.updateStudent = async (req, res) => {
   try {
     const enrollmentNo = req.params.enrollment_no;
     const {
-      user_id,
       student_name,
       program_name,
       school_name,
@@ -182,7 +167,6 @@ exports.updateStudent = async (req, res) => {
 
     // Validate required fields
     if (
-      !user_id ||
       !student_name ||
       !program_name ||
       !school_name ||
@@ -229,34 +213,21 @@ exports.updateStudent = async (req, res) => {
       return res.status(404).json({ message: "Student not found" });
     }
 
-    // Check if user_id already exists for a different student
-    const userIdCheck = await db.query(
-      "SELECT COUNT(*) FROM student WHERE user_id = $1 AND enrollment_no != $2",
-      [user_id, enrollmentNo]
-    );
+    // Skip user_id validation - will be preserved or set when user account is created
 
-    if (parseInt(userIdCheck.rows[0].count) > 0) {
-      return res.status(409).json({
-        message: "Another student with this user ID already exists",
-      });
-    }
-
-    // Update student
-    const result = await db.query(
+    // Update student (preserve existing user_id)
+    await db.query(
       `UPDATE student 
-       SET user_id = $1, 
-           student_name = $2, 
-           program_id = $3, 
-           school_id = $4, 
-           program_name = $5, 
-           school_name = $6, 
-           year_admitted = $7, 
-           email_id = $8,
+       SET student_name = $1, 
+           program_id = $2, 
+           school_id = $3, 
+           program_name = $4, 
+           school_name = $5, 
+           year_admitted = $6, 
+           email_id = $7,
            updated_at = CURRENT_TIMESTAMP
-       WHERE enrollment_no = $9
-       RETURNING *`,
+       WHERE enrollment_no = $8`,
       [
-        user_id,
         student_name,
         program_id,
         school_id,
@@ -336,10 +307,9 @@ exports.importStudents = async (req, res) => {
       return res.status(400).json({ message: "Excel file has no data" });
     }
 
-    // Validate Excel data structure
+    // Validate Excel data structure (user_id removed - will be set when user account is created)
     const requiredFields = [
       "enrollment_no",
-      "user_id",
       "student_name",
       "program_name",
       "school_name",
@@ -411,26 +381,15 @@ exports.importStudents = async (req, res) => {
           );
         }
 
-        // Check if user_id already exists
-        const userIdCheck = await db.query(
-          "SELECT COUNT(*) FROM student WHERE user_id = $1",
-          [row.user_id]
-        );
+        // Skip user_id validation - will be set when user account is created
 
-        if (parseInt(userIdCheck.rows[0].count) > 0) {
-          throw new Error(
-            `A student with user ID '${row.user_id}' already exists`
-          );
-        }
-
-        // Insert the student
+        // Insert the student without user_id (will be set when user account is created)
         await db.query(
           `INSERT INTO student 
-           (enrollment_no, user_id, student_name, program_id, school_id, program_name, school_name, year_admitted, email_id) 
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+           (enrollment_no, student_name, program_id, school_id, program_name, school_name, year_admitted, email_id) 
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
           [
             row.enrollment_no,
-            row.user_id,
             row.student_name,
             programId,
             schoolId,

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -824,7 +824,6 @@
                   <thead>
                     <tr>
                       <th>Enrollment No.</th>
-                      <th>User ID</th>
                       <th>Student Name</th>
                       <th>Program</th>
                       <th>School</th>
@@ -836,7 +835,7 @@
                   </thead>
                   <tbody id="students-table">
                     <tr>
-                      <td colspan="9" class="text-center">
+                      <td colspan="8" class="text-center">
                         Loading students...
                       </td>
                     </tr>
@@ -3546,18 +3545,7 @@
                   Unique enrollment/registration number (e.g., BTCS2301)
                 </div>
               </div>
-              <div class="mb-3">
-                <label for="student-userid-field" class="form-label"
-                  >User ID *</label
-                >
-                <input
-                  type="number"
-                  class="form-control"
-                  id="student-userid-field"
-                  required
-                />
-                <div class="form-text">Unique integer ID for the student</div>
-              </div>
+              <!-- User ID field removed - will be set automatically when user account is created -->
               <div class="mb-3">
                 <label for="student-name-field" class="form-label"
                   >Student Name *</label
@@ -3664,13 +3652,15 @@
             </p>
             <ul>
               <li>enrollment_no (required)</li>
-              <li>user_id (required)</li>
               <li>student_name (required)</li>
               <li>program_name (required)</li>
               <li>school_name (required)</li>
               <li>year_admitted (required)</li>
               <li>email_id (optional)</li>
             </ul>
+            <div class="alert alert-info">
+              <strong>Note:</strong> Do NOT include user_id column in your Excel file. User IDs will be set automatically when user accounts are created.
+            </div>
             <div class="mb-3">
               <label for="student-file-input" class="form-label"
                 >Select Excel File</label

--- a/src/public/js/students.js
+++ b/src/public/js/students.js
@@ -12,7 +12,7 @@ let studentYearFilter;
 // Student form elements
 let studentForm;
 let studentEnrollmentInput;
-let studentUserIdInput;
+// studentUserIdInput removed - user_id will be set automatically when user account is created
 let studentNameInput;
 let studentProgramInput;
 let studentSchoolInput;
@@ -60,7 +60,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // Initialize form elements
   studentForm = document.getElementById("student-form");
   studentEnrollmentInput = document.getElementById("student-enrollment-field");
-  studentUserIdInput = document.getElementById("student-userid-field");
+  // studentUserIdInput removed - user_id field no longer exists in form
   studentNameInput = document.getElementById("student-name-field");
   studentProgramInput = document.getElementById("student-program-field");
   studentSchoolInput = document.getElementById("student-school-field");
@@ -378,7 +378,7 @@ function renderStudents(students) {
         student.student_name.toLowerCase().includes(searchTerm) ||
         (student.email_id &&
           student.email_id.toLowerCase().includes(searchTerm)) ||
-        student.user_id.toString().includes(searchTerm)
+        false // user_id search removed
       );
     }
 
@@ -406,7 +406,7 @@ function renderStudents(students) {
 
     row.innerHTML = `
       <td>${student.enrollment_no}</td>
-      <td>${student.user_id}</td>
+      <!-- User ID column removed -->
       <td>${student.student_name}</td>
       <td>${student.program_name}</td>
       <td>${student.school_name}</td>
@@ -550,7 +550,7 @@ function openEditStudentModal(enrollmentNo) {
         studentEnrollmentInput.value = student.enrollment_no;
         studentEnrollmentInput.disabled = true; // Disable enrollment for editing
       }
-      if (studentUserIdInput) studentUserIdInput.value = student.user_id;
+      // studentUserIdInput no longer exists - user_id will be set when user account is created
       if (studentNameInput) studentNameInput.value = student.student_name;
       if (studentProgramInput) studentProgramInput.value = student.program_name;
       if (studentSchoolInput) studentSchoolInput.value = student.school_name;
@@ -593,17 +593,16 @@ function handleSaveStudent() {
   const enrollmentNo = studentEnrollmentInput
     ? studentEnrollmentInput.value.trim()
     : "";
-  const userId = studentUserIdInput ? studentUserIdInput.value.trim() : "";
+  // userId removed - will be set automatically when user account is created
   const studentName = studentNameInput ? studentNameInput.value.trim() : "";
   const programName = studentProgramInput ? studentProgramInput.value : "";
   const schoolName = studentSchoolInput ? studentSchoolInput.value : "";
   const yearAdmitted = studentYearInput ? studentYearInput.value : "";
   const emailId = studentEmailInput ? studentEmailInput.value.trim() : "";
 
-  // Validate required fields
+  // Validate required fields (userId validation removed)
   if (
     !enrollmentNo ||
-    !userId ||
     !studentName ||
     !programName ||
     !schoolName ||
@@ -613,10 +612,9 @@ function handleSaveStudent() {
     return;
   }
 
-  // Prepare data
+  // Prepare data (user_id removed)
   const studentData = {
     enrollment_no: enrollmentNo,
-    user_id: parseInt(userId),
     student_name: studentName,
     program_name: programName,
     school_name: schoolName,


### PR DESCRIPTION
- Remove user_id field from manual student creation form and validation
- Remove user_id column requirement from Excel import process
- Update frontend to remove User ID field from Add Student form
- Remove User ID column from students table display
- Update import instructions to exclude user_id column

This ensures user_id is only set when user accounts are created, preventing the session mixing issue where students would see wrong names/data after login due to mismatched user_ids.

