### PR TITLE
fix: display faculty names for both theory and lab components in TEL …

### DIFF
--- a/src/controllers/course-registration.controller.js
+++ b/src/controllers/course-registration.controller.js
@@ -1510,12 +1510,14 @@ exports.getStudentSlotTimetable = async (req, res) => {
         );
 
         for (const slotGroup of slotGroups) {
-          // Check if this slot group also contains "+" (like "L9+L10")
-          if (slotGroup.includes("+")) {
-            // Further split by "+" for individual slots
+          // Check if this slot group contains "+" and is a theory slot (not a lab slot)
+          // Lab slots like "L9+L10" should NOT be split as they represent single 2-hour sessions
+          // Only split theory slots like "A1+TA1" for 4-credit courses
+          if (slotGroup.includes("+") && !slotGroup.match(/^L\d+\+L\d+$/)) {
+            // This is a theory compound slot like "A1+TA1" - split it
             const individualSlots = slotGroup.split("+").map((s) => s.trim());
             console.log(
-              `🔍 Processing plus-separated slots in group: ${slotGroup} -> ${individualSlots.join(", ")}`
+              `🔍 Processing plus-separated theory slots: ${slotGroup} -> ${individualSlots.join(", ")}`
             );
 
             for (const individualSlot of individualSlots) {
@@ -1539,7 +1541,7 @@ exports.getStudentSlotTimetable = async (req, res) => {
               }
             }
           } else {
-            // Single slot in this group
+            // Single slot or lab compound slot (like "L9+L10") - keep as is
             const slotDetails = await db.query(
               `SELECT slot_day, slot_time FROM slot 
                WHERE slot_name = $1 AND slot_year = $2 AND semester_type = $3`,
@@ -1560,13 +1562,14 @@ exports.getStudentSlotTimetable = async (req, res) => {
             }
           }
         }
-      } else if (registration.slot_name.includes("+")) {
+      } else if (registration.slot_name.includes("+") && !registration.slot_name.match(/^L\d+\+L\d+$/)) {
         // Handle plus-separated compound slots like "A1+TA1" (4-credit theory courses)
+        // Do NOT split lab compound slots like "L9+L10" as they are single 2-hour sessions
         const individualSlots = registration.slot_name
           .split("+")
           .map((s) => s.trim());
         console.log(
-          `🔍 Processing plus-separated compound slot: ${
+          `🔍 Processing plus-separated theory compound slot: ${
             registration.slot_name
           } -> ${individualSlots.join(", ")}`
         );
@@ -1990,9 +1993,10 @@ exports.getAdminStudentTimetable = async (req, res) => {
         const slotGroups = reg.slot_name.split(',');
         for (const slotGroup of slotGroups) {
           const trimmedGroup = slotGroup.trim();
-          // Check if this slot group also contains "+" (like "L9+L10")
-          if (trimmedGroup.includes('+')) {
-            // Further split by "+" for individual slots
+          // Check if this slot group contains "+" and is a theory slot (not a lab slot)
+          // Lab slots like "L9+L10" should NOT be split as they represent single 2-hour sessions
+          if (trimmedGroup.includes('+') && !trimmedGroup.match(/^L\d+\+L\d+$/)) {
+            // Further split by "+" for individual theory slots only
             const individualSlots = trimmedGroup.split('+').map((s) => s.trim());
             for (const individualSlot of individualSlots) {
               const slotDetails = await db.query(
@@ -2044,8 +2048,9 @@ exports.getAdminStudentTimetable = async (req, res) => {
             }
           }
         }
-      } else if (reg.slot_name && reg.slot_name.includes('+')) {
+      } else if (reg.slot_name && reg.slot_name.includes('+') && !reg.slot_name.match(/^L\d+\+L\d+$/)) {
         // Handle plus-separated compound slots like "A1+TA1" (4-credit theory courses)
+        // Do NOT split lab compound slots like "L9+L10" as they are single 2-hour sessions
         const individualSlots = reg.slot_name.split('+').map((s) => s.trim());
         for (const individualSlot of individualSlots) {
           const slotDetails = await db.query(
@@ -2106,9 +2111,10 @@ exports.getAdminStudentTimetable = async (req, res) => {
         const slotGroups = reg.slot_name.split(',');
         for (const slotGroup of slotGroups) {
           const trimmedGroup = slotGroup.trim();
-          // Check if this slot group also contains "+" (like "L9+L10")
-          if (trimmedGroup.includes('+')) {
-            // Further split by "+" for individual slots
+          // Check if this slot group contains "+" and is a theory slot (not a lab slot)
+          // Lab slots like "L9+L10" should NOT be split as they represent single 2-hour sessions
+          if (trimmedGroup.includes('+') && !trimmedGroup.match(/^L\d+\+L\d+$/)) {
+            // Further split by "+" for individual theory slots only
             const individualSlots = trimmedGroup.split('+').map((s) => s.trim());
             for (const individualSlot of individualSlots) {
               const slotDetails = await db.query(
@@ -2162,8 +2168,9 @@ exports.getAdminStudentTimetable = async (req, res) => {
             }
           }
         }
-      } else if (reg.slot_name && reg.slot_name.includes('+')) {
+      } else if (reg.slot_name && reg.slot_name.includes('+') && !reg.slot_name.match(/^L\d+\+L\d+$/)) {
         // Handle plus-separated compound slots like "A1+TA1" (4-credit theory courses)
+        // Do NOT split lab compound slots like "L9+L10" as they are single 2-hour sessions
         const individualSlots = reg.slot_name.split('+').map((s) => s.trim());
         for (const individualSlot of individualSlots) {
           const slotDetails = await db.query(

--- a/src/public/js/admin-student-timetable.js
+++ b/src/public/js/admin-student-timetable.js
@@ -364,6 +364,7 @@ function displayAdminTimetableResults(data, year, semester) {
         }
       });
 
+
       // Build timetable structure
       const days = ["MON", "TUE", "WED", "THU", "FRI"];
       const timeSlots = [
@@ -692,7 +693,8 @@ function generateAdminSummaryTable(allRegistrations) {
     courseMap.get(key).components.push({
       slot_name: reg.slot_name,
       venue: reg.venue,
-      component_type: reg.component_type
+      component_type: reg.component_type,
+      faculty_name: reg.faculty_name
     });
   });
 
@@ -739,7 +741,7 @@ function generateAdminSummaryTable(allRegistrations) {
           <td>${index === 0 ? course.course_type : ''}</td>
           <td>${comp.slot_name}</td>
           <td>${comp.venue}</td>
-          <td>${index === 0 ? course.faculty_name : ''}</td>
+          <td>${comp.faculty_name || ''}</td>
           <td>${comp.component_type}</td>
           <td>${index === 0 ? '<span class="badge bg-success">Registered</span>' : ''}</td>
         </tr>
@@ -759,7 +761,7 @@ function generateAdminSummaryTable(allRegistrations) {
           <td>${index === 0 ? course.course_type : ''}</td>
           <td>${comp.slot_name}</td>
           <td>${comp.venue}</td>
-          <td>${index === 0 ? course.faculty_name : ''}</td>
+          <td>${comp.faculty_name || ''}</td>
           <td>${comp.component_type}</td>
           <td>${index === 0 ? '<span class="badge bg-danger">Withdrawn</span>' : ''}</td>
         </tr>

--- a/src/public/js/course-registration.js
+++ b/src/public/js/course-registration.js
@@ -1594,7 +1594,8 @@ function generateEnhancedSummaryTable(allRegistrations) {
     courseMap.get(key).components.push({
       slot_name: reg.slot_name,
       venue: reg.venue,
-      component_type: reg.component_type
+      component_type: reg.component_type,
+      faculty_name: reg.faculty_name
     });
   });
 
@@ -1641,7 +1642,7 @@ function generateEnhancedSummaryTable(allRegistrations) {
           <td>${index === 0 ? course.course_type : ''}</td>
           <td>${comp.slot_name}</td>
           <td>${comp.venue}</td>
-          <td>${index === 0 ? course.faculty_name : ''}</td>
+          <td>${comp.faculty_name || ''}</td>
           <td>${comp.component_type}</td>
           <td>${index === 0 ? '<span class="badge bg-success">Registered</span>' : ''}</td>
         </tr>
@@ -1661,7 +1662,7 @@ function generateEnhancedSummaryTable(allRegistrations) {
           <td>${index === 0 ? course.course_type : ''}</td>
           <td>${comp.slot_name}</td>
           <td>${comp.venue}</td>
-          <td>${index === 0 ? course.faculty_name : ''}</td>
+          <td>${comp.faculty_name || ''}</td>
           <td>${comp.component_type}</td>
           <td>${index === 0 ? '<span class="badge bg-danger">Withdrawn</span>' : ''}</td>
         </tr>

--- a/src/public/js/student-timetable.js
+++ b/src/public/js/student-timetable.js
@@ -227,6 +227,7 @@ function generateStandaloneTimetable(student, registrations, allRegistrations, y
         }
       });
 
+
       // Build timetable structure
       const days = ["MON", "TUE", "WED", "THU", "FRI"];
       const timeSlots = [
@@ -487,7 +488,8 @@ function generateEnhancedSummaryTable(allRegistrations) {
     courseMap.get(key).components.push({
       slot_name: reg.slot_name,
       venue: reg.venue,
-      component_type: reg.component_type
+      component_type: reg.component_type,
+      faculty_name: reg.faculty_name
     });
   });
 
@@ -534,7 +536,7 @@ function generateEnhancedSummaryTable(allRegistrations) {
           <td>${index === 0 ? course.course_type : ''}</td>
           <td>${comp.slot_name}</td>
           <td>${comp.venue}</td>
-          <td>${index === 0 ? course.faculty_name : ''}</td>
+          <td>${comp.faculty_name || ''}</td>
           <td>${comp.component_type}</td>
           <td>${index === 0 ? '<span class="badge bg-success">Registered</span>' : ''}</td>
         </tr>
@@ -554,7 +556,7 @@ function generateEnhancedSummaryTable(allRegistrations) {
           <td>${index === 0 ? course.course_type : ''}</td>
           <td>${comp.slot_name}</td>
           <td>${comp.venue}</td>
-          <td>${index === 0 ? course.faculty_name : ''}</td>
+          <td>${comp.faculty_name || ''}</td>
           <td>${comp.component_type}</td>
           <td>${index === 0 ? '<span class="badge bg-danger">Withdrawn</span>' : ''}</td>
         </tr>


### PR DESCRIPTION
…courses and restore lab slot details in timetable

- Store faculty_name at component level instead of course level in summary tables
- TEL courses now show faculty names for both theory and lab components
- Fix backend slot splitting logic to preserve lab compound slots like "L9+L10"
- Only split theory compound slots like "A1+TA1" for 4-credit courses
- Lab compound slots represent single 2-hour sessions and should not be split
- Resolves missing course details in timetable grid lab slots

