### PR TITLE
fix: restore class slot timetable display for compound theory slots

### DIFF
--- a/src/controllers/faculty-allocation.controller.js
+++ b/src/controllers/faculty-allocation.controller.js
@@ -818,6 +818,11 @@ exports.getClassTimetable = async (req, res) => {
        ORDER BY fa.slot_day, fa.slot_time`,
       [venue, year, semesterType]
     );
+    
+    console.log(`🔍 Class timetable for ${venue}: Found ${allocationsResult.rows.length} allocations`);
+    if (allocationsResult.rows.length > 0) {
+      console.log('🔍 Sample allocation slot names:', allocationsResult.rows.slice(0, 3).map(a => a.slot_name));
+    }
 
     res.status(200).json({
       venue: venueDetails,

--- a/src/public/js/faculty-allocation.js
+++ b/src/public/js/faculty-allocation.js
@@ -2745,8 +2745,24 @@ function generateClassTimetable(venue, allocations, year, semester) {
       // Create allocation map
       const allocationMap = {};
       allocations.forEach((allocation) => {
-        const key = `${allocation.slot_day}-${allocation.slot_name}`;
-        allocationMap[key] = allocation;
+        // For T=4 combined slots like "A1+TA1", create entries for both the combined name and individual components
+        if (allocation.slot_name.includes('+') && !allocation.slot_name.includes(',') && !allocation.slot_name.startsWith('L')) {
+          // T=4 theory slot - create entries for both combined and individual slot names
+          const key = `${allocation.slot_day}-${allocation.slot_name}`;
+          allocationMap[key] = allocation;
+          
+          // Also create entries using the component slot names for lookup
+          const components = allocation.slot_name.split('+');
+          components.forEach(component => {
+            const componentKey = `${allocation.slot_day}-${component}`;
+            allocationMap[componentKey] = allocation;
+          });
+          console.log(`🔍 Created T=4 entries for ${allocation.slot_name} on ${allocation.slot_day}: component keys for ${components.join(', ')}`);
+        } else {
+          // Regular slot
+          const key = `${allocation.slot_day}-${allocation.slot_name}`;
+          allocationMap[key] = allocation;
+        }
       });
 
       // Use EXACT same logic as master timetable


### PR DESCRIPTION
- Fix allocation map building logic to handle T=4 compound theory slots like "A1+TA1"
- Create individual component entries (A1, TA1) that map to compound allocation data
- Frontend can now find allocations when looking up individual slot components
- Resolves empty/incomplete class timetables for venues with 4-credit theory courses
- Add debug logging for compound slot processing