### PR TITLE
feat: allow timetable coordinators to edit/delete faculty allocations

### DIFF
--- a/src/controllers/faculty-allocation.controller.js
+++ b/src/controllers/faculty-allocation.controller.js
@@ -903,11 +903,55 @@ exports.deleteFacultyAllocation = async (req, res) => {
       });
     }
 
+    // Check if students are registered for this allocation
+    // First, get the faculty name by joining with faculty table
+    const allocationCheck = await db.query(
+      `SELECT f.name as faculty_name
+       FROM faculty_allocation fa
+       JOIN faculty f ON fa.employee_id = f.employee_id
+       WHERE fa.slot_year = $1 AND fa.semester_type = $2 AND fa.course_code = $3
+       AND fa.employee_id = $4 AND fa.venue = $5 AND fa.slot_day = $6
+       AND fa.slot_name = $7 AND fa.slot_time = $8`,
+      [
+        slot_year,
+        semester_type,
+        course_code,
+        employee_id,
+        venue,
+        slot_day,
+        slot_name,
+        slot_time,
+      ]
+    );
+
+    if (allocationCheck.rowCount === 0) {
+      return res.status(404).json({ message: "Faculty allocation not found" });
+    }
+
+    const faculty_name = allocationCheck.rows[0].faculty_name;
+
+    // Check for student registrations
+    const studentCheck = await db.query(
+      `SELECT COUNT(*) as student_count
+       FROM student_registrations
+       WHERE course_code = $1 AND slot_year = $2 AND semester_type = $3
+       AND slot_name = $4 AND venue = $5 AND faculty_name = $6`,
+      [course_code, slot_year, semester_type, slot_name, venue, faculty_name]
+    );
+
+    const studentCount = parseInt(studentCheck.rows[0].student_count);
+
+    if (studentCount > 0) {
+      return res.status(400).json({
+        message: `Cannot delete this faculty allocation. ${studentCount} student(s) are already registered for this course allocation. Please remove student registrations first.`,
+      });
+    }
+
     // Delete the primary allocation
     const result = await db.query(
-      `DELETE FROM faculty_allocation 
-       WHERE slot_year = $1 AND semester_type = $2 AND course_code = $3 
-       AND employee_id = $4 AND venue = $5 AND slot_day = $6 
+      `DELETE FROM faculty_allocation
+       WHERE slot_year = $1 AND semester_type = $2 AND course_code = $3
+       AND employee_id = $4 AND venue = $5 AND slot_day = $6
        AND slot_name = $7 AND slot_time = $8
        RETURNING *`,
       [

--- a/src/public/js/faculty-allocation.js
+++ b/src/public/js/faculty-allocation.js
@@ -544,19 +544,19 @@ function renderFacultyAllocations(allocations) {
         <td>${firstAllocation.venue}</td>
         <td>
           ${
-            currentUser && currentUser.role === "admin"
+            currentUser && (currentUser.role === "admin" || currentUser.role === "timetable_coordinator")
               ? `
-            <button class="btn btn-sm btn-primary edit-allocation-btn" 
+            <button class="btn btn-sm btn-primary edit-allocation-btn"
               data-allocation='${JSON.stringify(firstAllocation)}'>
               <i class="fas fa-edit"></i>
+            </button>
+            <button class="btn btn-sm btn-danger delete-allocation-btn"
+              data-allocation='${JSON.stringify(firstAllocation)}'>
+              <i class="fas fa-trash"></i>
             </button>
           `
               : ""
           }
-          <button class="btn btn-sm btn-danger delete-allocation-btn" 
-            data-allocation='${JSON.stringify(firstAllocation)}'>
-            <i class="fas fa-trash"></i>
-          </button>
         </td>
       `;
       facultyAllocationTableBody.appendChild(row);
@@ -652,19 +652,19 @@ function renderFacultyAllocations(allocations) {
           <td>${allocation.venue}</td>
           <td>
             ${
-              currentUser && currentUser.role === "admin"
+              currentUser && (currentUser.role === "admin" || currentUser.role === "timetable_coordinator")
                 ? `
-              <button class="btn btn-sm btn-primary edit-allocation-btn" 
+              <button class="btn btn-sm btn-primary edit-allocation-btn"
                 data-allocation='${JSON.stringify(allocation)}'>
                 <i class="fas fa-edit"></i>
+              </button>
+              <button class="btn btn-sm btn-danger delete-allocation-btn"
+                data-allocation='${JSON.stringify(allocation)}'>
+                <i class="fas fa-trash"></i>
               </button>
             `
                 : ""
             }
-            <button class="btn btn-sm btn-danger delete-allocation-btn" 
-              data-allocation='${JSON.stringify(allocation)}'>
-              <i class="fas fa-trash"></i>
-            </button>
           </td>
         `;
         facultyAllocationTableBody.appendChild(row);


### PR DESCRIPTION
- Updated frontend role checks to show edit and delete buttons for timetable coordinators
- Wrapped delete buttons in role check for consistency (previously visible to all users)
- Added validation to prevent deletion of allocations with student registrations
- Backend middleware already supported timetable coordinators - this was a frontend-only fix