### PR TITLE
fix: resolve semesters page not loading data

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -4744,7 +4744,6 @@
 
       console.log("Using API URL:", window.API_URL);
     </script>
-    <script src="js/main.js"></script>
     <script src="js/auth.js"></script>
     <script src="js/schools.js"></script>
     <script src="js/semesters.js"></script>
@@ -4767,5 +4766,7 @@
     <script src="js/courses-view.js"></script>
     <script src="js/student-auth.js"></script>
     <script src="js/attendance.js"></script>
+    <!-- Load main.js LAST so all module functions are available -->
+    <script src="js/main.js"></script>
   </body>
 </html>

--- a/src/public/js/main.js
+++ b/src/public/js/main.js
@@ -357,6 +357,10 @@ function setupNavigation() {
               `;
             }
           }
+        } else if (targetPage === "semesters-page") {
+          if (typeof loadSemesters === "function") {
+            loadSemesters();
+          }
         }
         // Add other page data loading as needed
       } else {

--- a/src/public/js/semesters.js
+++ b/src/public/js/semesters.js
@@ -140,13 +140,31 @@ function loadSemesters() {
       return response.json();
     })
     .then((semesters) => {
-      // Rest of your function...
+      console.log("DEBUG - Semesters data:", semesters);
+      if (semesters.length === 0) {
+        if (semestersTableBody) {
+          semestersTableBody.innerHTML =
+            '<tr><td colspan="5" class="text-center">No semesters found. Add a new semester to get started.</td></tr>';
+        }
+        return;
+      }
+
+      // Render the semesters
+      renderSemesters(semesters);
     })
     .catch((error) => {
       console.error("Load semesters error:", error);
-      // Rest of your error handling...
+      if (semestersTableBody) {
+        semestersTableBody.innerHTML =
+          '<tr><td colspan="5" class="text-center text-danger">Error loading semesters. Please try again.</td></tr>';
+      }
+      showAlert("Failed to load semesters. Please try again.", "danger");
     });
 }
+
+// Expose loadSemesters globally so main.js can call it
+window.loadSemesters = loadSemesters;
+
 // Render semesters in the table
 function renderSemesters(semesters) {
   if (!semestersTableBody) {


### PR DESCRIPTION
- Add missing implementation in loadSemesters() function (was placeholder comment)
- Expose loadSemesters globally so main.js can call it
- Add handler for semesters-page in main.js navigation
- Move main.js to load last so all module functions are available
- Add proper error handling and empty state

This fixes the issue where semesters page would show "Loading semesters..." indefinitely because the fetched data was never rendered to the table.

