### PR TITLE
fix: lower rate limit to 3 per worker for PM2 cluster mode

### DIFF
--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -5,10 +5,11 @@ const { verifyToken, isAdmin } = require("../middleware/auth.middleware");
 
 const router = express.Router();
 
-// Rate limiter for login endpoint: max 10 attempts per IP per 15 minutes
+// Rate limiter for login endpoint: max 3 attempts per worker per 15 minutes
+// (PM2 cluster mode runs 4 workers, so effective limit is ~12 total attempts)
 const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 10,
+  max: 3,
   message: {
     message: "Too many login attempts. Please try again after 15 minutes.",
   },

--- a/src/routes/student-auth.routes.js
+++ b/src/routes/student-auth.routes.js
@@ -5,10 +5,11 @@ const { verifyToken } = require("../middleware/auth.middleware");
 
 const router = express.Router();
 
-// Rate limiter for login endpoint: max 10 attempts per IP per 15 minutes
+// Rate limiter for login endpoint: max 3 attempts per worker per 15 minutes
+// (PM2 cluster mode runs 4 workers, so effective limit is ~12 total attempts)
 const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 10,
+  max: 3,
   message: {
     message: "Too many login attempts. Please try again after 15 minutes.",
   },


### PR DESCRIPTION
Production runs 4 PM2 cluster workers, each with its own in-memory rate limit counter. Lowering from 10 to 3 per worker gives an effective limit of ~12 total attempts per IP per 15 minutes.