### PR TITLE
fix: remove plain-text password from login attempt logs

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -9,7 +9,7 @@ const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "1h";
 // Login controller
 exports.login = async (req, res) => {
   try {
-    console.log("Login attempt:", req.body);
+    console.log("Login attempt:", { username: req.body.username });
     const { username, password } = req.body;
 
     // Validate input

--- a/src/controllers/student-auth.controller.js
+++ b/src/controllers/student-auth.controller.js
@@ -9,7 +9,7 @@ const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "1h";
 // Student login controller
 exports.studentLogin = async (req, res) => {
   try {
-    console.log("Student login attempt:", req.body);
+    console.log("Student login attempt:", { username: req.body.username });
     const { username, password } = req.body;
 
     // Validate input


### PR DESCRIPTION
Log only the username instead of the entire req.body to prevent passwords from appearing in server logs.