### PR TITLE
fix: skip successful logins from rate limit and increase max for campus NAT

### DIFF
--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -5,11 +5,14 @@ const { verifyToken, isAdmin } = require("../middleware/auth.middleware");
 
 const router = express.Router();
 
-// Rate limiter for login endpoint: max 3 attempts per worker per 15 minutes
-// (PM2 cluster mode runs 4 workers, so effective limit is ~12 total attempts)
+// Rate limiter for login endpoint: max 15 failed attempts per worker per 15 minutes
+// - skipSuccessfulRequests: successful logins don't count toward the limit
+// - Higher max to account for campus/university users sharing the same public IP (NAT)
+// - PM2 cluster mode runs 4 workers, so effective limit is ~60 failed attempts per IP
 const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 3,
+  max: 15,
+  skipSuccessfulRequests: true,
   message: {
     message: "Too many login attempts. Please try again after 15 minutes.",
   },

--- a/src/routes/student-auth.routes.js
+++ b/src/routes/student-auth.routes.js
@@ -5,11 +5,14 @@ const { verifyToken } = require("../middleware/auth.middleware");
 
 const router = express.Router();
 
-// Rate limiter for login endpoint: max 3 attempts per worker per 15 minutes
-// (PM2 cluster mode runs 4 workers, so effective limit is ~12 total attempts)
+// Rate limiter for login endpoint: max 15 failed attempts per worker per 15 minutes
+// - skipSuccessfulRequests: successful logins don't count toward the limit
+// - Higher max to account for campus/university users sharing the same public IP (NAT)
+// - PM2 cluster mode runs 4 workers, so effective limit is ~60 failed attempts per IP
 const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 3,
+  max: 15,
+  skipSuccessfulRequests: true,
   message: {
     message: "Too many login attempts. Please try again after 15 minutes.",
   },


### PR DESCRIPTION


- Add skipSuccessfulRequests so correct logins never count toward limit
- Increase max from 3 to 15 per worker (~60 total with 4 PM2 workers)
- Prevents blocking legitimate campus users sharing the same public IP