### PR TITLE
feat: add course registration block list for students with admin holds

### DIFF
--- a/src/controllers/course-registration.controller.js
+++ b/src/controllers/course-registration.controller.js
@@ -1,4 +1,33 @@
 const db = require("../config/db");
+const { getActiveBlock } = require("../utils/registration-block");
+
+// Tells the frontend whether the current student is blocked from registration.
+// Always callable (no checkRegistrationEnabled gate) so the student sees the
+// banner even when the registration window is closed.
+exports.getBlockStatus = async (req, res) => {
+  try {
+    if (req.userRole !== "student") {
+      return res.status(200).json({ blocked: false });
+    }
+    const student = await getStudentByUserId(req.userId);
+    if (!student) {
+      return res.status(200).json({ blocked: false });
+    }
+    const activeBlock = await getActiveBlock(student.enrollment_number);
+    if (!activeBlock) {
+      return res.status(200).json({ blocked: false });
+    }
+    res.status(200).json({
+      blocked: true,
+      reason: activeBlock.block_reason,
+      notes: activeBlock.notes,
+      blocked_at: activeBlock.blocked_at,
+    });
+  } catch (error) {
+    console.error("Get block status error:", error);
+    res.status(500).json({ message: "Server error while checking block status" });
+  }
+};
 
 // Get available academic years and semesters
 exports.getAvailableSemesters = async (req, res) => {
@@ -34,6 +63,20 @@ exports.getCoursesForSemester = async (req, res) => {
       return res.status(400).json({
         message: "slot_year and semester_type are required",
       });
+    }
+
+    // For students on the block list, return an empty course list. The block
+    // banner is shown by the frontend via the /block-status endpoint, so we
+    // just suppress the data here as a defense-in-depth layer. Admin/staff
+    // browsing the endpoint, and admin impersonation, bypass.
+    if (req.userRole === "student" && !req.impersonatedBy) {
+      const student = await getStudentByUserId(req.userId);
+      if (student) {
+        const activeBlock = await getActiveBlock(student.enrollment_number);
+        if (activeBlock) {
+          return res.status(200).json([]);
+        }
+      }
     }
 
     // Get both regular and project courses
@@ -1084,10 +1127,23 @@ exports.registerCourseOffering = async (req, res) => {
     // Get student details
     const student = await getStudentByUserId(userId);
 
+    // Reject registration if this student is on the block list (pending fees,
+    // suspension, etc.). Admin impersonation bypasses the check.
+    if (!req.impersonatedBy) {
+      const activeBlock = await getActiveBlock(student.enrollment_number);
+      if (activeBlock) {
+        return res.status(403).json({
+          message: `Registration blocked: ${activeBlock.block_reason}. Please contact the accounts office.`,
+          registrationBlocked: true,
+          reason: activeBlock.block_reason,
+        });
+      }
+    }
+
     // Get course details
     const courseResult = await db.query(
       `SELECT course_code, course_name, theory, practical, credits, course_type
-       FROM course 
+       FROM course
        WHERE course_code = $1`,
       [course_code]
     );
@@ -2575,6 +2631,19 @@ exports.registerTELCourseAtomic = async (req, res) => {
 
     // Get student details
     const student = await getStudentByUserId(userId);
+
+    // Reject TEL registration if this student is on the block list. Admin
+    // impersonation bypasses the check.
+    if (!req.impersonatedBy) {
+      const activeBlock = await getActiveBlock(student.enrollment_number);
+      if (activeBlock) {
+        return res.status(403).json({
+          message: `Registration blocked: ${activeBlock.block_reason}. Please contact the accounts office.`,
+          registrationBlocked: true,
+          reason: activeBlock.block_reason,
+        });
+      }
+    }
 
     // Get course details
     const courseResult = await db.query(

--- a/src/controllers/registration-block.controller.js
+++ b/src/controllers/registration-block.controller.js
@@ -1,0 +1,250 @@
+const db = require("../config/db");
+const XLSX = require("xlsx");
+
+// List currently blocked students (joined with student name + program).
+// Optional ?search= matches enrollment_no or student name.
+exports.listBlocks = async (req, res) => {
+  try {
+    const search = (req.query.search || "").trim();
+    const params = [];
+    let where = "WHERE b.unblocked_at IS NULL";
+    if (search) {
+      params.push(`%${search}%`);
+      where += ` AND (b.enrollment_no ILIKE $${params.length} OR s.student_name ILIKE $${params.length})`;
+    }
+
+    const result = await db.query(
+      `SELECT b.block_id, b.enrollment_no, b.block_reason, b.notes,
+              b.blocked_at, b.blocked_by,
+              s.student_name, s.program_name,
+              u.username AS blocked_by_username
+         FROM student_registration_block b
+         JOIN student s ON s.enrollment_no = b.enrollment_no
+         LEFT JOIN "user" u ON u.user_id = b.blocked_by
+         ${where}
+         ORDER BY b.blocked_at DESC`,
+      params
+    );
+
+    res.status(200).json(result.rows);
+  } catch (error) {
+    console.error("List registration blocks error:", error);
+    res.status(500).json({ message: "Server error while listing registration blocks" });
+  }
+};
+
+const DEFAULT_BLOCK_REASON = "Administrative hold";
+
+// Add a block for a single student.
+exports.addBlock = async (req, res) => {
+  try {
+    const enrollmentNo = String(req.body.enrollment_no || "").trim();
+    const blockReason =
+      String(req.body.block_reason || "").trim() || DEFAULT_BLOCK_REASON;
+    const notes = req.body.notes ? String(req.body.notes).trim() || null : null;
+
+    if (!enrollmentNo) {
+      return res.status(400).json({
+        message: "enrollment_no is required",
+      });
+    }
+
+    const studentCheck = await db.query(
+      `SELECT 1 FROM student WHERE enrollment_no = $1`,
+      [enrollmentNo]
+    );
+    if (studentCheck.rows.length === 0) {
+      return res.status(404).json({
+        message: `Student with enrollment_no '${enrollmentNo}' not found`,
+      });
+    }
+
+    const existing = await db.query(
+      `SELECT 1 FROM student_registration_block
+        WHERE enrollment_no = $1 AND unblocked_at IS NULL`,
+      [enrollmentNo]
+    );
+    if (existing.rows.length > 0) {
+      return res.status(409).json({
+        message: `Student '${enrollmentNo}' is already on the block list`,
+      });
+    }
+
+    const result = await db.query(
+      `INSERT INTO student_registration_block
+         (enrollment_no, block_reason, notes, blocked_by)
+       VALUES ($1, $2, $3, $4)
+       RETURNING block_id, enrollment_no, block_reason, notes, blocked_at`,
+      [enrollmentNo, blockReason, notes, req.userId]
+    );
+
+    res.status(201).json(result.rows[0]);
+  } catch (error) {
+    console.error("Add registration block error:", error);
+    res.status(500).json({ message: "Server error while adding registration block" });
+  }
+};
+
+// Bulk upload from Excel. Mirrors the importStudents pattern.
+// Required columns: enrollment_no, block_reason. Optional: notes.
+exports.importBlocks = async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ message: "Please upload an Excel file" });
+    }
+
+    const workbook = XLSX.read(req.file.buffer, { type: "buffer" });
+    const worksheet = workbook.Sheets[workbook.SheetNames[0]];
+    const rawData = XLSX.utils.sheet_to_json(worksheet);
+
+    if (rawData.length === 0) {
+      return res.status(400).json({ message: "Excel file has no data" });
+    }
+
+    // Normalize headers: trim whitespace and lowercase so trailing spaces in
+    // header cells don't break the upload.
+    const data = rawData.map((row) => {
+      const normalized = {};
+      for (const k of Object.keys(row)) {
+        normalized[String(k).trim().toLowerCase()] = row[k];
+      }
+      return normalized;
+    });
+
+    // Only enrollment_no column is required. block_reason and notes are optional.
+    const allKeys = new Set();
+    data.forEach((row) => Object.keys(row).forEach((k) => allKeys.add(k)));
+    if (!allKeys.has("enrollment_no")) {
+      return res.status(400).json({
+        message: "Excel file is missing required field: enrollment_no",
+        expectedFields: ["enrollment_no", "block_reason (optional)", "notes (optional)"],
+      });
+    }
+
+    await db.query("BEGIN");
+
+    const results = {
+      total: data.length,
+      imported: 0,
+      skippedAlreadyBlocked: 0,
+      errors: [],
+    };
+
+    for (let i = 0; i < data.length; i++) {
+      const row = data[i];
+      try {
+        const enrollmentNo = String(row.enrollment_no || "").trim();
+        const blockReason =
+          String(row.block_reason || "").trim() || DEFAULT_BLOCK_REASON;
+        const notes = row.notes ? String(row.notes).trim() || null : null;
+
+        if (!enrollmentNo) throw new Error("enrollment_no is empty");
+
+        const studentCheck = await db.query(
+          `SELECT 1 FROM student WHERE enrollment_no = $1`,
+          [enrollmentNo]
+        );
+        if (studentCheck.rows.length === 0) {
+          throw new Error(`Student '${enrollmentNo}' not found`);
+        }
+
+        const existing = await db.query(
+          `SELECT 1 FROM student_registration_block
+            WHERE enrollment_no = $1 AND unblocked_at IS NULL`,
+          [enrollmentNo]
+        );
+        if (existing.rows.length > 0) {
+          results.skippedAlreadyBlocked++;
+          continue;
+        }
+
+        await db.query(
+          `INSERT INTO student_registration_block
+             (enrollment_no, block_reason, notes, blocked_by)
+           VALUES ($1, $2, $3, $4)`,
+          [enrollmentNo, blockReason, notes, req.userId]
+        );
+
+        results.imported++;
+      } catch (error) {
+        results.errors.push({ row: i + 2, message: error.message });
+      }
+    }
+
+    if (results.imported > 0 || results.skippedAlreadyBlocked > 0) {
+      await db.query("COMMIT");
+    } else {
+      await db.query("ROLLBACK");
+      return res.status(400).json({
+        message: "No students were blocked due to errors",
+        results,
+      });
+    }
+
+    res.status(200).json({
+      message: `Imported ${results.imported} of ${results.total} (skipped ${results.skippedAlreadyBlocked} already-blocked)`,
+      results,
+    });
+  } catch (error) {
+    await db.query("ROLLBACK");
+    console.error("Import registration blocks error:", error);
+    res.status(500).json({
+      message: "Server error while importing registration blocks",
+      error: error.message,
+    });
+  }
+};
+
+// Unblock a student. Sets unblocked_at / unblocked_by on the active row.
+exports.unblockStudent = async (req, res) => {
+  try {
+    const { enrollment_no } = req.params;
+
+    const result = await db.query(
+      `UPDATE student_registration_block
+          SET unblocked_at = CURRENT_TIMESTAMP, unblocked_by = $2
+        WHERE enrollment_no = $1 AND unblocked_at IS NULL
+        RETURNING block_id, enrollment_no, unblocked_at`,
+      [enrollment_no, req.userId]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({
+        message: `No active block found for '${enrollment_no}'`,
+      });
+    }
+
+    res.status(200).json({
+      message: `Student '${enrollment_no}' has been unblocked`,
+      record: result.rows[0],
+    });
+  } catch (error) {
+    console.error("Unblock student error:", error);
+    res.status(500).json({ message: "Server error while unblocking student" });
+  }
+};
+
+// History of all block/unblock records for a student (active + past).
+exports.getHistory = async (req, res) => {
+  try {
+    const { enrollment_no } = req.params;
+
+    const result = await db.query(
+      `SELECT b.block_id, b.enrollment_no, b.block_reason, b.notes,
+              b.blocked_at, b.blocked_by, b.unblocked_at, b.unblocked_by,
+              ub.username AS blocked_by_username,
+              uu.username AS unblocked_by_username
+         FROM student_registration_block b
+         LEFT JOIN "user" ub ON ub.user_id = b.blocked_by
+         LEFT JOIN "user" uu ON uu.user_id = b.unblocked_by
+        WHERE b.enrollment_no = $1
+        ORDER BY b.blocked_at DESC`,
+      [enrollment_no]
+    );
+
+    res.status(200).json(result.rows);
+  } catch (error) {
+    console.error("Get block history error:", error);
+    res.status(500).json({ message: "Server error while fetching block history" });
+  }
+};

--- a/src/db/migrations/create_student_registration_block.sql
+++ b/src/db/migrations/create_student_registration_block.sql
@@ -1,0 +1,27 @@
+-- Migration: Create student_registration_block table
+-- Holds students who are blocked from course registration (e.g. pending tuition fees,
+-- suspension). Blocking does NOT disable login or other portal features. Soft-delete
+-- via unblocked_at/unblocked_by preserves audit history.
+
+CREATE TABLE IF NOT EXISTS student_registration_block (
+    block_id      SERIAL PRIMARY KEY,
+    enrollment_no VARCHAR(20) NOT NULL REFERENCES student(enrollment_no) ON DELETE CASCADE,
+    block_reason  VARCHAR(255) NOT NULL,
+    notes         TEXT,
+    blocked_by    INTEGER NOT NULL REFERENCES "user"(user_id),
+    blocked_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    unblocked_by  INTEGER REFERENCES "user"(user_id),
+    unblocked_at  TIMESTAMP
+);
+
+-- Partial index: only one active block per student is the common lookup.
+CREATE INDEX IF NOT EXISTS idx_srb_active_lookup
+    ON student_registration_block (enrollment_no)
+    WHERE unblocked_at IS NULL;
+
+-- Index for history view per student
+CREATE INDEX IF NOT EXISTS idx_srb_enrollment
+    ON student_registration_block (enrollment_no);
+
+COMMENT ON TABLE student_registration_block IS
+    'Students blocked from course registration. Soft-deleted via unblocked_at; row remains for audit.';

--- a/src/db/schema/student_registration_block.sql
+++ b/src/db/schema/student_registration_block.sql
@@ -1,0 +1,23 @@
+-- Students blocked from course registration (pending fees, suspension, etc.)
+-- Blocking does NOT disable login; only blocks the course registration flow.
+
+CREATE TABLE student_registration_block (
+    block_id      SERIAL PRIMARY KEY,
+    enrollment_no VARCHAR(20) NOT NULL,
+    block_reason  VARCHAR(255) NOT NULL,
+    notes         TEXT,
+    blocked_by    INTEGER NOT NULL,
+    blocked_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    unblocked_by  INTEGER,
+    unblocked_at  TIMESTAMP,
+    FOREIGN KEY (enrollment_no) REFERENCES student(enrollment_no) ON DELETE CASCADE,
+    FOREIGN KEY (blocked_by) REFERENCES "user"(user_id),
+    FOREIGN KEY (unblocked_by) REFERENCES "user"(user_id)
+);
+
+CREATE INDEX idx_srb_active_lookup
+    ON student_registration_block (enrollment_no)
+    WHERE unblocked_at IS NULL;
+
+CREATE INDEX idx_srb_enrollment
+    ON student_registration_block (enrollment_no);

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -167,6 +167,12 @@
                 </a>
               </li>
               <li class="nav-item">
+                <a class="nav-link" href="#" id="registration-blocks-link">
+                  <i class="fas fa-ban me-2"></i>
+                  Registration Blocks
+                </a>
+              </li>
+              <li class="nav-item">
                 <a class="nav-link" href="#" id="timetable-link">
                   <i class="fas fa-clock me-2"></i>
                   TimeTable
@@ -943,6 +949,75 @@
                       <td colspan="8" class="text-center">
                         Loading students...
                       </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <!-- Registration Blocks Page -->
+            <div id="registration-blocks-page" class="content-page">
+              <div class="d-flex justify-content-between mb-4 flex-wrap gap-2">
+                <div class="d-flex gap-2 flex-wrap align-items-center">
+                  <button type="button" class="btn btn-warning" id="add-block-btn">
+                    <i class="fas fa-ban"></i> Add Block
+                  </button>
+                  <label class="btn btn-success mb-0">
+                    <i class="fas fa-upload"></i> Choose Excel
+                    <input
+                      type="file"
+                      id="block-file-input"
+                      accept=".xlsx,.xls"
+                      hidden
+                    />
+                  </label>
+                  <span id="block-file-info" class="text-muted small"></span>
+                  <button
+                    type="button"
+                    class="btn btn-primary"
+                    id="upload-blocks-btn"
+                    disabled
+                  >
+                    Upload
+                  </button>
+                </div>
+                <div class="d-flex">
+                  <input
+                    type="text"
+                    class="form-control"
+                    id="block-search-input"
+                    placeholder="Search enrollment or name..."
+                    style="min-width: 250px;"
+                  />
+                </div>
+              </div>
+
+              <div class="alert alert-info">
+                <small>
+                  Excel format — <code>enrollment_no</code> (required),
+                  <code>block_reason</code> (optional, defaults to "Administrative
+                  hold"), <code>notes</code> (optional). Blocked students
+                  <strong>can still login</strong>; only course registration is
+                  disabled.
+                </small>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-striped table-hover">
+                  <thead>
+                    <tr>
+                      <th>Enrollment No.</th>
+                      <th>Student Name</th>
+                      <th>Program</th>
+                      <th>Reason</th>
+                      <th>Notes</th>
+                      <th>Blocked By / At</th>
+                      <th>Action</th>
+                    </tr>
+                  </thead>
+                  <tbody id="blocks-table">
+                    <tr>
+                      <td colspan="7" class="text-center">Loading...</td>
                     </tr>
                   </tbody>
                 </table>
@@ -5223,6 +5298,7 @@
     <script src="js/attendance.js"></script>
     <script src="js/od.js"></script>
     <script src="js/marks.js"></script>
+    <script src="js/registration-blocks.js"></script>
     <!-- Load main.js LAST so all module functions are available -->
     <script src="js/main.js"></script>
   </body>

--- a/src/public/js/course-registration.js
+++ b/src/public/js/course-registration.js
@@ -115,9 +115,54 @@ function replaceWithWorkingCourseRegistration() {
   initializeWorkingFunctionality();
 }
 
+// Render an inline banner explaining why a student can't register.
+function renderRegistrationBlockBanner(reason) {
+  const container = document.getElementById(
+    "student-course-registration-content"
+  );
+  if (!container) return;
+  const safeReason = String(reason || "Administrative hold").replace(
+    /[<>&]/g,
+    (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;" }[c])
+  );
+  container.innerHTML = `
+    <div style="padding: 20px;">
+      <h2 style="color: #007bff; margin-bottom: 20px;">📚 Course Registration</h2>
+      <div class="alert alert-warning" role="alert"
+           style="border-left: 5px solid #f0ad4e; padding: 20px; max-width: 700px;">
+        <h4 style="margin-top: 0;">⚠ You are currently blocked from course registration.</h4>
+        <p style="margin-bottom: 5px;"><strong>Reason:</strong> ${safeReason}</p>
+        <p style="margin-bottom: 0;">Please contact the accounts office to resolve this and try again.</p>
+      </div>
+    </div>
+  `;
+}
+
 // Initialize working functionality
 async function initializeWorkingFunctionality() {
   console.log("⚙️ Setting up course registration functionality...");
+
+  // Check block status first; if blocked, show banner and stop.
+  try {
+    const blockResp = await fetch(
+      `${window.API_URL}/course-registration/block-status`,
+      {
+        headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+      }
+    );
+    if (blockResp.ok) {
+      const blockData = await blockResp.json();
+      if (blockData.blocked) {
+        console.log("🚫 Student is blocked from registration:", blockData.reason);
+        renderRegistrationBlockBanner(blockData.reason);
+        return;
+      }
+    }
+  } catch (err) {
+    // Non-fatal — if block-status fails, fall through and let the submit-time
+    // check guard the actual registration action.
+    console.warn("Block-status check failed (non-fatal):", err);
+  }
 
   // Load semesters
   try {

--- a/src/public/js/main.js
+++ b/src/public/js/main.js
@@ -178,6 +178,7 @@ function updateNavigationByRole(userRole) {
     staff: document.getElementById("staff-link"),
     users: document.getElementById("users-link"),
     students: document.getElementById("students-link"),
+    registrationBlocks: document.getElementById("registration-blocks-link"),
     timetable: document.getElementById("timetable-link"),
     timetableCoordinator: document.getElementById("timetable-coordinator-link"),
     projectAllocation: document.getElementById("project-allocation-link"),

--- a/src/public/js/registration-blocks.js
+++ b/src/public/js/registration-blocks.js
@@ -1,0 +1,205 @@
+// Admin "Registration Blocks" page — manage students blocked from course registration.
+
+(function () {
+  let isInitialized = false;
+  let fileInput, fileInfo, uploadBtn;
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const link = document.getElementById("registration-blocks-link");
+    if (link) {
+      link.addEventListener("click", () => {
+        initializeRegistrationBlocks();
+        loadBlocks();
+      });
+    }
+  });
+
+  function initializeRegistrationBlocks() {
+    if (isInitialized) return;
+    isInitialized = true;
+
+    const addBtn = document.getElementById("add-block-btn");
+    if (addBtn) addBtn.addEventListener("click", handleAddBlock);
+
+    const search = document.getElementById("block-search-input");
+    if (search) {
+      let timer;
+      search.addEventListener("input", () => {
+        clearTimeout(timer);
+        timer = setTimeout(() => loadBlocks(search.value.trim()), 250);
+      });
+    }
+
+    fileInput = document.getElementById("block-file-input");
+    fileInfo = document.getElementById("block-file-info");
+    uploadBtn = document.getElementById("upload-blocks-btn");
+
+    if (fileInput) {
+      fileInput.addEventListener("change", () => {
+        if (fileInput.files && fileInput.files[0]) {
+          if (fileInfo) fileInfo.textContent = fileInput.files[0].name;
+          if (uploadBtn) uploadBtn.disabled = false;
+        } else {
+          if (fileInfo) fileInfo.textContent = "";
+          if (uploadBtn) uploadBtn.disabled = true;
+        }
+      });
+    }
+    if (uploadBtn) uploadBtn.addEventListener("click", handleUpload);
+  }
+
+  function authHeaders(extra = {}) {
+    return {
+      Authorization: `Bearer ${localStorage.getItem("token")}`,
+      ...extra,
+    };
+  }
+
+  async function loadBlocks(search = "") {
+    const tbody = document.getElementById("blocks-table");
+    if (!tbody) return;
+    tbody.innerHTML =
+      '<tr><td colspan="7" class="text-center">Loading...</td></tr>';
+    try {
+      const url = search
+        ? `${window.API_URL}/registration-blocks?search=${encodeURIComponent(search)}`
+        : `${window.API_URL}/registration-blocks`;
+      const resp = await fetch(url, { headers: authHeaders() });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const rows = await resp.json();
+      renderBlocks(rows);
+    } catch (err) {
+      tbody.innerHTML = `<tr><td colspan="7" class="text-center text-danger">Failed to load: ${err.message}</td></tr>`;
+    }
+  }
+
+  function escapeHtml(s) {
+    return String(s == null ? "" : s).replace(
+      /[<>&"']/g,
+      (c) =>
+        ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;", "'": "&#39;" }[c])
+    );
+  }
+
+  function renderBlocks(rows) {
+    const tbody = document.getElementById("blocks-table");
+    if (!tbody) return;
+    if (!rows || rows.length === 0) {
+      tbody.innerHTML =
+        '<tr><td colspan="7" class="text-center">No students currently blocked.</td></tr>';
+      return;
+    }
+    tbody.innerHTML = rows
+      .map((r) => {
+        const blockedAt = r.blocked_at ? new Date(r.blocked_at).toLocaleString() : "";
+        return `
+          <tr>
+            <td>${escapeHtml(r.enrollment_no)}</td>
+            <td>${escapeHtml(r.student_name)}</td>
+            <td>${escapeHtml(r.program_name)}</td>
+            <td>${escapeHtml(r.block_reason)}</td>
+            <td>${escapeHtml(r.notes || "")}</td>
+            <td><small>${escapeHtml(r.blocked_by_username || "")}<br>${escapeHtml(blockedAt)}</small></td>
+            <td>
+              <button class="btn btn-sm btn-success unblock-btn"
+                      data-enrollment="${escapeHtml(r.enrollment_no)}">
+                Unblock
+              </button>
+            </td>
+          </tr>`;
+      })
+      .join("");
+
+    tbody.querySelectorAll(".unblock-btn").forEach((btn) => {
+      btn.addEventListener("click", () =>
+        handleUnblock(btn.getAttribute("data-enrollment"))
+      );
+    });
+  }
+
+  async function handleAddBlock() {
+    const enr = prompt("Enrollment number to block:");
+    if (enr === null) return;
+    const reason =
+      prompt("Reason for block (optional — e.g. Pending tuition fees):") || "";
+    const notes = prompt("Notes (optional, leave blank to skip):") || "";
+
+    try {
+      const resp = await fetch(`${window.API_URL}/registration-blocks`, {
+        method: "POST",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          enrollment_no: enr.trim(),
+          block_reason: reason.trim() || null,
+          notes: notes.trim() || null,
+        }),
+      });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.message || `HTTP ${resp.status}`);
+      alert(`✅ Blocked ${enr.trim()}`);
+      loadBlocks();
+    } catch (err) {
+      alert(`❌ ${err.message}`);
+    }
+  }
+
+  async function handleUnblock(enrollmentNo) {
+    if (!confirm(`Unblock student ${enrollmentNo}?`)) return;
+    try {
+      const resp = await fetch(
+        `${window.API_URL}/registration-blocks/${encodeURIComponent(enrollmentNo)}/unblock`,
+        { method: "PUT", headers: authHeaders() }
+      );
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.message || `HTTP ${resp.status}`);
+      alert(`✅ ${data.message}`);
+      loadBlocks();
+    } catch (err) {
+      alert(`❌ ${err.message}`);
+    }
+  }
+
+  async function handleUpload() {
+    if (!fileInput || !fileInput.files || !fileInput.files[0]) return;
+    const formData = new FormData();
+    formData.append("file", fileInput.files[0]);
+
+    if (uploadBtn) {
+      uploadBtn.disabled = true;
+      uploadBtn.textContent = "Uploading...";
+    }
+
+    try {
+      const resp = await fetch(`${window.API_URL}/registration-blocks/import`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: formData,
+      });
+      const data = await resp.json();
+      const r = data.results || {};
+      let msg = data.message || "Upload complete";
+      if (r.errors && r.errors.length > 0) {
+        const firstErrors = r.errors
+          .slice(0, 5)
+          .map((e) => `Row ${e.row}: ${e.message}`)
+          .join("\n");
+        const more =
+          r.errors.length > 5 ? `\n…and ${r.errors.length - 5} more` : "";
+        msg += `\n\nErrors:\n${firstErrors}${more}`;
+      }
+      alert(msg);
+      if (resp.ok) {
+        fileInput.value = "";
+        if (fileInfo) fileInfo.textContent = "";
+        loadBlocks();
+      }
+    } catch (err) {
+      alert(`❌ ${err.message}`);
+    } finally {
+      if (uploadBtn) {
+        uploadBtn.disabled = true;
+        uploadBtn.textContent = "Upload";
+      }
+    }
+  }
+})();

--- a/src/routes/course-registration.routes.js
+++ b/src/routes/course-registration.routes.js
@@ -41,6 +41,14 @@ const checkRegistrationEnabled = async (req, res, next) => {
   }
 };
 
+// Block status — student-facing. No checkRegistrationEnabled middleware so the
+// banner shows even when registration window is closed.
+router.get(
+  "/block-status",
+  verifyToken,
+  courseRegistrationController.getBlockStatus
+);
+
 // Get available semesters (always available for viewing purposes)
 router.get(
   "/semesters",

--- a/src/routes/registration-block.routes.js
+++ b/src/routes/registration-block.routes.js
@@ -1,0 +1,23 @@
+const express = require("express");
+const multer = require("multer");
+const controller = require("../controllers/registration-block.controller");
+const { verifyToken, isAdmin } = require("../middleware/auth.middleware");
+
+const router = express.Router();
+
+const storage = multer.memoryStorage();
+const upload = multer({
+  storage: storage,
+  limits: { fileSize: 10 * 1024 * 1024 }, // 10MB limit
+});
+
+router.use(verifyToken);
+router.use(isAdmin);
+
+router.get("/", controller.listBlocks);
+router.post("/", controller.addBlock);
+router.post("/import", upload.single("file"), controller.importBlocks);
+router.put("/:enrollment_no/unblock", controller.unblockStudent);
+router.get("/history/:enrollment_no", controller.getHistory);
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -88,6 +88,7 @@ app.use("/api/project-allocations", projectAllocationRoutes);
 app.use("/api/marks", marksRoutes);
 app.use("/api/reports", reportsRoutes);
 app.use("/api/od", odRoutes);
+app.use("/api/registration-blocks", require("./routes/registration-block.routes"));
 
 // Root route
 app.get("/", (req, res) => {

--- a/src/utils/registration-block.js
+++ b/src/utils/registration-block.js
@@ -1,0 +1,15 @@
+const db = require("../config/db");
+
+async function getActiveBlock(enrollmentNo) {
+  if (!enrollmentNo) return null;
+  const result = await db.query(
+    `SELECT block_reason, notes, blocked_at
+       FROM student_registration_block
+      WHERE enrollment_no = $1 AND unblocked_at IS NULL
+      LIMIT 1`,
+    [enrollmentNo]
+  );
+  return result.rows[0] || null;
+}
+
+module.exports = { getActiveBlock };


### PR DESCRIPTION
Admins can maintain a list of students who are blocked from course registration (e.g. pending tuition fees, suspension) without disabling their login. The block is enforced inside the registration submit handlers and on the course-listing endpoint for students; a banner shown on the student registration page explains the reason. Unblocking a student is a soft-delete so the block/unblock history is retained for audit.